### PR TITLE
Droid report checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Currently parameterized tests are configured for SLV identifiers and will use `t
 
 #### Runner scripts
 
+- `droid_report_check.py` : Converts folders stage with `.ready` file, by validating a DROID report inside. Valid reports are moved to review directory and sets file to `.ok`. Otherwise the file is set to `.error` and the issues recorded.
 - `bagit_transfer.py` : Bags data and transfers it to a location. Transfers and collections are recorded in a sqlite3 database.    
 - `validate_transfers.py` : Runs validation over every bag in a directory. Each run and each check are recorded in a sqlite3 database. A HTML report is exported at the end.    
 - `transfer_report.py` : Generates a HTML report of all transfers in the database.
@@ -78,7 +79,7 @@ Example `.bat` script for empty file:
             for /D %%i in (*) do if not exist %%i.ok (
                 if not exist %%i.error (
                     if not exist %%i.processing (
-                        .> %%i.ok)))
+                        .> %%i.ready)))
 
 Example `.bat` script with metadata:
 
@@ -98,6 +99,8 @@ Example `.bat` script with metadata:
 #### Trigger file handling
 
 Staged transfers are handled based on the file extension, whether they have already been bagged, and whether they meet minimum validation requirements.
+
+Staff staging transfers create a trigger file with a `.ready` file extension. These will not be processed via the bagging workflow until they are converted to `.ok`. This can be done manually or automatically by checking a DROID report within the folder. 
 
 The `TriggerFile` class expects a `.ok` file submitted as a path. It performs basic validation checks:
 - Does the folder exist?

--- a/droid_report_check.py
+++ b/droid_report_check.py
@@ -193,7 +193,7 @@ def main():
         logging.info(droid_report)
         if len(droid_report) == 0:
             logging.warning(f"No droid report in {dir}")
-            errors.append("No droid report in folder.")
+            make_error_file(dir,"No droid report in folder.")
 
         validated_reports = []
 
@@ -255,7 +255,7 @@ def main():
             all_file = os.path.join(report_dir, f'{name}_all_{strftime("%Y-%m-%d")}.csv')
             df2.to_csv(all_file)
             print("Report written to: " + all_file)
-            if len(df2_error) > 0:
+            if len(df2_error) > 0 or len(errors) > 0:
                 df2_read_error = df2_error[df2_error['CURRENT_MD5'].str.startswith("Error")]
                 df2_match_error = df2_error[~df2_error['CURRENT_MD5'].str.startswith("Error")]
                 read_error_file = os.path.join(report_dir, f'{name}_error_read_{strftime("%Y-%m-%d")}.csv')
@@ -292,8 +292,6 @@ def main():
             if len(errors) == 0:
                 validated_reports.append(r)
             
-        if len(validated_reports) == 0:
-            make_error_file(dir, ", ".join(errors))
         for report in validated_reports:
             droid_report.remove(report)
         

--- a/droid_report_check.py
+++ b/droid_report_check.py
@@ -1,0 +1,291 @@
+import os
+import pandas as pd
+import logging
+import hashlib
+from time import strftime
+import json
+import sys
+
+
+def getHash(path, root):
+    hasher = hashlib.new('MD5')
+    location = os.path.join(root,path)
+    try:
+        with open(location, "rb") as f:
+            while True:
+                block = f.read((512 * 1024))
+                if not block:
+                    break
+                hasher.update(block)
+        outcome = hasher.hexdigest()
+    except Exception as e:
+        outcome = f"Error getting hash: {e}"
+    return outcome
+
+def check_droid_headers(current_headers: list) -> bool:
+    expected = ["ID","PARENT_ID","URI","FILE_PATH","NAME","METHOD","STATUS","SIZE","TYPE","EXT","LAST_MODIFIED","EXTENSION_MISMATCH","MD5_HASH"]
+    missing = []
+    for c in expected:
+                if c not in current_headers:
+                    missing.append(c)
+    if len(missing) > 0:
+        logging.warning(f"Headers not matched in report: {';'.join(missing)}")
+        return False
+    else:
+        return True
+
+def find_folder_path(original_path, example_file, current_directory):
+    while (True):
+        new_path = example_file.replace(original_path,current_directory)
+        if os.path.exists(new_path):
+            return original_path
+        elif len(original_path) <= 3:
+            print(f"Unable to find file {example_file} in current location.")
+            raise ValueError(f"Unable to find file {example_file} in current location.")
+        else:
+            original_path = os.path.normpath(original_path.replace(os.path.basename(original_path),""))
+
+def make_error_file(directory):
+    print("Making error file")
+    transfer_dir = os.getenv("TRANSFER_PATH")
+    if not os.path.exists(directory):
+        logging.warning(f"Doesn't exist {directory}")
+        return 
+    if not os.path.exists(transfer_dir):
+        logging.warning(f"Doesn't exist {directory}")
+        return
+    try: 
+        os.path.commonprefix([transfer_dir, directory])
+        d = os.path.relpath(directory,transfer_dir)
+        top_level = os.path.basename(d)
+        ok_path = os.path.join(transfer_dir,f"{top_level}.ok")
+        ready_path = os.path.join(transfer_dir,f"{top_level}.ready")
+        error_path = os.path.join(transfer_dir,f"{top_level}.error")
+        with open(error_path, 'w') as f:
+            f.write("Error validating DROID report. Check the logs for more information.")
+            logging.info("Creating error file for transfer.")
+        if os.path.exists(ok_path):
+            os.remove(ok_path)
+            logging.info("Removing .ok file for folder with errors.")
+        if os.path.exists(ready_path):
+            os.remove(ready_path)
+            logging.info("Removing .ready file for folder with errors.")
+    except ValueError as e:
+        logging.info(f"Path: {directory} and {transfer_dir} have no common path.")
+
+def make_ok_file(directory):
+    transfer_dir = os.getenv("TRANSFER_PATH")
+    try: 
+        os.path.commonprefix([transfer_dir, directory])
+        d = os.path.relpath(directory,transfer_dir)
+        top_level = os.path.basename(d)
+        ok_path = os.path.join(transfer_dir,f"{top_level}.ok")
+        ready_path = os.path.join(transfer_dir,f"{top_level}.ready")
+        with open(ok_path, 'w') as f:
+            f.write("DROID report validated.")
+            logging.info("Updating ready file to ok file for transfer.")
+        if os.path.exists(ready_path):
+            os.remove(ready_path)
+            logging.info("Removing .ready file for validated folder.")
+    except ValueError as e:
+        logging.error(f"Error making ok file: {e}")
+        make_error_file(directory)
+    
+
+def handle_irregular_csv(file):
+    # this is a bit hackey :(
+    with open(file, 'r', encoding='utf-8') as f:
+        longest = 0
+        # split assuming we have quoated data and commas
+        data = [line.split('","') for line in f]
+
+        # find the longest line
+        for line in data:
+            if len(line) > longest:
+                longest = len(line)
+
+        # tidy column names
+        col_names = [x.replace('"',"").replace("\n","") for x in data[0]]
+
+        # add column names for extra columns
+        for i in range(len(col_names),longest):
+            col_names.append(f"Column {i+1}")
+        data[0] = col_names
+
+        # add blank entries for any other short columns
+        for i in range(len(data)):
+            if len(data[i]) < longest:
+                to_add = [""] * (longest - len(data[i]))
+                data[i].extend(to_add)   
+        col_names = data[0]
+        data = data[1:]
+
+        # create indexed dictionary and load dataframe
+        total = {}
+        for i in range(longest):
+            total.update({str(i):data[i]})
+        df = pd.DataFrame.from_dict(total, orient="index", columns=col_names)
+        return df
+
+def load_directories(dir):
+    if dir is None:
+        logging.error("No transfer directory recorded.")
+        sys.exit()
+
+    # process each folder within a directory supplied as path
+    data = json.loads(dir)
+    data = data.get("path")
+    paths = os.listdir(dir)
+    ready_files = [x.replace(".ready","") for x in paths if x.endswith(".ready")]
+    logging.info("Processing READY files: " + ", ".join(ready_files))
+    if len(ready_files) == 0:
+        raise ValueError("No READY folders to process. Make sure READY files are staged using stage_files.bat.")
+    just_ready = [x for x in paths if x in ready_files]
+    full_paths = [os.path.join(dir, x) for x in just_ready]
+    directories = [x for x in full_paths if os.path.isdir(x)]
+    logging.info("Processing directories: " + ", ".join(directories))
+    dir_list = [os.path.join(dir, x) for x in just_ready]
+    logging.info("Final list of directories to be processed: " + ", ".join(dir_list))
+    return dir_list
+
+def load_csv(csv_file):
+    readerror = False
+    logging.info(f"Checking report: {csv_file}")
+    try:
+        df = pd.read_csv(csv_file)
+    except Exception as e:
+        logging.error(f"Error parsing as dataframe: {e}")
+        readerror = True
+        #continue
+    
+    if readerror:
+        df = handle_irregular_csv(csv_file)
+
+    return df
+
+def main():
+    transfer_dir = os.getenv("TRANSFER_DIR")
+    logging_dir = os.getenv("LOGGING_DIR")
+    output_directory = os.getenv("REPORT_DIR")
+    droid_output_dir = os.getenv("DROID_OUTPUT_DIR")
+    
+
+    logfilename = f"{strftime('%Y%m%d')}_check_DROID_report.log"
+    logfile = os.path.join(logging_dir, logfilename)
+
+    logging.basicConfig(
+        filename=logfile,
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # check the variables are loaded
+
+    report_dir = os.path.join(output_directory,"droid_report_check")
+    if not os.path.exists(report_dir):
+        os.mkdir(report_dir)
+
+    dir_list = load_directories(transfer_dir)
+
+    for dir in dir_list:
+        files = os.listdir(dir)
+
+        droid_report = [x for x in files if 'droid' in x.lower()]
+        logging.info(droid_report)
+        if len(droid_report) == 0:
+            logging.warning(f"No droid report in {dir}")
+            print(f"No droid report in {dir}")
+            make_error_file(dir)
+
+        validated_reports = []
+
+        for r in droid_report:
+            csv_file = os.path.join(dir,r)
+            df = load_csv(csv_file)
+            
+            # validate as a DROID report by checking expected headers
+            cols = df.head()
+            if not check_droid_headers(cols):
+                continue
+
+            # DROID report store absolute paths at time of generation
+            # script tries to find a legit path to the files
+            root_path = df.iloc[0].FILE_PATH
+            # drop folders
+            files_only = df[df["TYPE"]!="Folder"]
+            rows = len(files_only.index)
+            logging.info(f"Dropping folders - reducing manifest size from {len(df.index)} to {rows}, ")
+            # drop items inside archive formats
+            files_only = files_only[files_only["URI"].str.startswith("file")]
+            logging.info(f"Dropping files within archive formats - reducing manifest size from {rows} to {len(files_only.index)}")
+            example_file = files_only.iloc[0].FILE_PATH
+
+            try:
+                to_replace = find_folder_path(root_path, example_file, dir)
+            except Exception as e:
+                print(f"Error: {e} - have files been renamed?")
+                logging.error(f"Error: {e} - have files been renamed?")
+                continue
+            name = os.path.basename(os.path.normpath(dir))
+            files_only.loc[:,'CHECKED_PATH'] = files_only.loc[:,"FILE_PATH"].str.replace(to_replace,dir)
+
+            fdf = files_only
+
+            # generate hashes of files in current locations
+            fdf['CURRENT_MD5'] = fdf['CHECKED_PATH'].apply(lambda x: getHash(x, dir))
+
+            # compare generated hashes against existing
+            fdf['STILL_VALID'] = (fdf['MD5_HASH']==fdf['CURRENT_MD5'])
+
+            # filter to relevant fields for report
+            df2 = fdf.loc[:,['STILL_VALID','FILE_PATH', 'MD5_HASH', 'CURRENT_MD5', 'CHECKED_PATH']]
+            df2_error = df2[df2['STILL_VALID']==False]
+
+            # generate reports and write to file.
+            name, ext = os.path.splitext(r)
+            all_file = os.path.join(report_dir, f'{name}_all_{strftime("%Y-%m-%d")}.csv')
+            df2.to_csv(all_file)
+            print("Report written to: " + all_file)
+            if len(df2_error) > 0:
+                make_error_file(dir)
+                df2_read_error = df2_error[df2_error['CURRENT_MD5'].str.startswith("Error")]
+                df2_match_error = df2_error[~df2_error['CURRENT_MD5'].str.startswith("Error")]
+                read_error_file = os.path.join(report_dir, f'{name}_error_read_{strftime("%Y-%m-%d")}.csv')
+                match_error_file = os.path.join(report_dir, f'{name}_error_match_{strftime("%Y-%m-%d")}.csv')
+                if (len(df2_read_error) > 0):
+                    df2_read_error.to_csv(read_error_file)
+                    logging.warning(f"Read errors identified.")
+                else:
+                    logging.warning("No read errors identified")
+                if (len(df2_match_error) > 0):
+                    df2_match_error.to_csv(match_error_file)
+                    logging.warning("File match errors identified.")
+                else:
+                    logging.info("No match errors identified")
+            else:
+                make_ok_file(dir)
+                logging.info("====SUCCESS: Data matches report!====")
+                logging.info("Moving DROID report to done folder.")
+                os.rename(csv_file, os.path.join(droid_output_dir,r))
+                print(f"Moved {csv_file} to {os.path.join(droid_output_dir,r)}")
+
+            validated_reports.append(r)
+            
+        for report in validated_reports:
+            droid_report.remove(report)
+        
+        logging.info(f"Files successfully processed:")
+        if len(validated_reports) > 0:
+            print(f"Files successfully processed:")
+            for r in validated_reports:
+                logging.info(r)
+                print(r)
+        if len(droid_report) > 0:
+            logging.info(f"Files not recognised as DROID reports:")
+            print(f"Files not recognised as DROID reports:")
+            for f in droid_report:
+                logging.info(f)
+                print(f)
+
+if __name__ == "__main__":
+    main()

--- a/droid_report_check.py
+++ b/droid_report_check.py
@@ -228,6 +228,16 @@ def main():
             name = os.path.basename(os.path.normpath(dir))
             files_only.loc[:,'CHECKED_PATH'] = files_only.loc[:,"FILE_PATH"].str.replace(to_replace,dir)
 
+            ## Check all the files in storage are in Droid report. 
+            for root, directory, files in os.walk(dir):
+                name_data = files_only.NAME.copy().to_list()
+                for f in files:
+                    if f not in name_data:
+                        errors.append(f"Manifest does not contain file: {f}")
+                    else:
+                        name_data.remove(f)
+
+
             fdf = files_only
 
             # generate hashes of files in current locations

--- a/env.example
+++ b/env.example
@@ -8,3 +8,4 @@ REPORT_DIR = "//home/logs"
 HASH_ALGORITHMS = "md5,sha256" # optional, ensure they are comma separated.
 SOURCE_ORG = "Organisation name" # optional, to add a default value for source org. 
 APPRAISAL_DIR = "//home/appraisal-dir"
+DROID_OUTPUT_DIR= "//home/droid-report-dir/"

--- a/src/helper_functions.py
+++ b/src/helper_functions.py
@@ -28,6 +28,7 @@ def load_config() -> dict:
         "SOURCE_ORG": os.getenv("SOURCE_ORG"),
         "REPORT_DIR": os.getenv("REPORT_DIR"),
         "APPRAISAL_DIR": os.getenv("APPRAISAL_DIR"),
+        "DROID_OUTPUT_DIR": os.getenv("DROID_OUTPUT_DIR")
     }
     return config
 

--- a/tests/data/droid-test/droid-test_DROID.csv
+++ b/tests/data/droid-test/droid-test_DROID.csv
@@ -1,0 +1,3 @@
+"ID","PARENT_ID","URI","FILE_PATH","NAME","METHOD","STATUS","SIZE","TYPE","EXT","LAST_MODIFIED","EXTENSION_MISMATCH","MD5_HASH","FORMAT_COUNT","PUID","MIME_TYPE","FORMAT_NAME","FORMAT_VERSION"
+"2","","file:/E:/droid-test/","E:\droid-test","droid-test","","Done","","Folder","","2025-12-17T10:45:02","false","","","","","",""
+"3","2","file:/E:/droid-test/test_file_01.txt","E:\droid-test\test_file_01.txt","test_file_01.txt","Extension","Done","20","File","txt","2025-12-17T10:45:09","false","3de8f8b0dc94b8c2230fab9ec0ba0506","1","x-fmt/111","text/plain","Plain Text File",""

--- a/tests/data/droid-test/test_file_01.txt
+++ b/tests/data/droid-test/test_file_01.txt
@@ -1,0 +1,1 @@
+This is a test file.

--- a/tests/test_droid_report_check.py
+++ b/tests/test_droid_report_check.py
@@ -1,0 +1,129 @@
+from droid_report_check import *
+import shutil
+import pytest
+
+@pytest.fixture
+def stable_path(tmp_path):
+    return tmp_path
+
+@pytest.fixture
+def mock_config(stable_path):
+    logging_dir = stable_path / "logging"
+    transfer = stable_path / "transfer"
+    report = stable_path / "report"
+    droid_output = stable_path / "droid_output"
+    dirs = [logging_dir, transfer, report, droid_output]
+    for dir in dirs:
+        os.mkdir(dir)
+    config = {
+        "LOGGING_DIR": str(logging_dir),
+        "REPORT_DIR": str(report),
+        "TRANSFER_DIR": str(transfer),
+        "DROID_OUTPUT_DIR": str(droid_output),
+    }
+    return config
+
+@pytest.fixture
+def simple_transfer(mock_config):
+    staging = mock_config.get("TRANSFER_DIR")
+    shutil.copytree(os.path.join(os.getcwd(),"tests","data"),staging, dirs_exist_ok=True)
+
+# successful validation run
+def test_simple_transfer_is_ok(stable_path, mock_config, simple_transfer, monkeypatch):
+    transfer_dir = os.path.join(stable_path, "transfer")
+
+    # set config
+    monkeypatch.setattr("droid_report_check.load_config", lambda: mock_config)
+    # run main
+    main()
+
+    expected = os.path.join(transfer_dir, "droid-test.ok")
+    assert os.path.exists(expected)
+
+def test_simple_transfer_moves_droid_report(stable_path, mock_config, simple_transfer, monkeypatch):
+    transfer_dir = os.path.join(stable_path, "transfer")
+
+    # set config
+    monkeypatch.setattr("droid_report_check.load_config", lambda: mock_config)
+    # run main
+    main()
+
+    unexpected = os.path.join(transfer_dir, "droid-test","droid-test_DROID.csv")
+    exists = os.path.exists(unexpected)
+    assert not exists
+
+def test_catches_extra_file(stable_path, mock_config, simple_transfer, monkeypatch):
+    transfer_dir = os.path.join(stable_path, "transfer")
+    new_file = os.path.join(transfer_dir,"droid-test","extrafile.txt")
+    droid_report = os.path.join(transfer_dir,"droid-test","droid-test_DROID.csv")
+    with open (new_file, 'w') as f:
+        f.write('something')
+
+    # set config
+    monkeypatch.setattr("droid_report_check.load_config", lambda: mock_config)
+    # run main
+    main()
+
+    expected = os.path.join(transfer_dir, "droid-test.error")
+    expected_error = "Manifest does not contain file: extrafile.txt"
+    with open(expected, 'r') as f:
+        error = ",".join(f.readlines())
+    assert os.path.exists(expected)
+    assert error == expected_error
+    assert os.path.isfile(droid_report)
+
+def test_catches_changed_file(stable_path, mock_config, simple_transfer, monkeypatch):
+    transfer_dir = os.path.join(stable_path, "transfer")
+    new_file = os.path.join(transfer_dir,"droid-test","test_file_01.txt")
+    droid_report = os.path.join(transfer_dir,"droid-test","droid-test_DROID.csv")
+    with open (new_file, 'w') as f:
+        f.write('something')
+
+    # set config
+    monkeypatch.setattr("droid_report_check.load_config", lambda: mock_config)
+    # run main
+    main()
+
+    expected = os.path.join(transfer_dir, "droid-test.error")
+    expected_error = "File match errors identified"
+    with open(expected, 'r') as f:
+        error = ",".join(f.readlines())
+    assert os.path.exists(expected)
+    assert error == expected_error
+    assert os.path.isfile(droid_report)
+
+def test_catches_missing_droid_report(stable_path, mock_config, simple_transfer, monkeypatch):
+    transfer_dir = os.path.join(stable_path, "transfer")
+    droid_report = os.path.join(transfer_dir,"droid-test","droid-test_DROID.csv")
+    os.remove(droid_report)
+
+    # set config
+    monkeypatch.setattr("droid_report_check.load_config", lambda: mock_config)
+    # run main
+    main()
+
+    expected = os.path.join(transfer_dir, "droid-test.error")
+    expected_error = "No droid report in folder."
+    with open(expected, 'r') as f:
+        error = ",".join(f.readlines())
+    assert os.path.exists(expected)
+    assert error == expected_error
+
+def test_catches_missing_file(stable_path, mock_config, simple_transfer, monkeypatch):
+    transfer_dir = os.path.join(stable_path, "transfer")
+    droid_report = os.path.join(transfer_dir,"droid-test","droid-test_DROID.csv")
+    new_file = os.path.join(transfer_dir,"droid-test","test_file_01.txt")
+    os.remove(new_file)
+
+    # set config
+    monkeypatch.setattr("droid_report_check.load_config", lambda: mock_config)
+    # run main
+    main()
+
+    expected = os.path.join(transfer_dir, "droid-test.error")
+    expected_error = "Error: Unable to find file"
+    with open(expected, 'r') as f:
+        error = ",".join(f.readlines())
+    assert os.path.exists(expected)
+    assert error.startswith(expected_error)
+    assert os.path.isfile(droid_report)


### PR DESCRIPTION
Introduces functionality to optionally check a staged bag against a DROID report within the top level folder. 

If the droid report matches the data, the trigger file is set from `.ready` to `.ok`.

The process may fail for any of the following reasons, which will be written to the `.error` file and the `.ready` file will be removed.
- Files present in directory that are not in the manifest (including Thumbs.db)
- Files not present in the directory that are in the manifest.
- Changes to file checksum.
- Missing DROID report.